### PR TITLE
Segment UI into multiple pages with basic styling

### DIFF
--- a/public/courses.html
+++ b/public/courses.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cursos</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body onload="loadCourses()">
+  <nav>
+    <a href="home.html">Home</a>
+    <a href="index.html">Inicio</a>
+  </nav>
+  <div class="container">
+    <h2>Listado de Cursos</h2>
+    <ul id="courses"></ul>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/home.html
+++ b/public/home.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Home</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body onload="requireAuth(); loadCourses(); document.getElementById('welcome').innerText = 'Hola ' + (user.name || ''); if(user.role !== 'teacher'){document.getElementById('course-create').style.display='none';}">
+  <nav>
+    <a href="courses.html">Cursos</a>
+    <a href="profile.html">Perfil</a>
+    <a href="#" onclick="logout()">Salir</a>
+  </nav>
+  <div class="container">
+    <h2 id="welcome"></h2>
+    <section id="course-create">
+      <h3>Crear Curso (Maestros)</h3>
+      <input id="course-title" placeholder="Título" />
+      <input id="course-description" placeholder="Descripción" />
+      <textarea id="course-content" placeholder="Contenido"></textarea>
+      <button onclick="createCourse()">Crear</button>
+      <div id="course-result"></div>
+    </section>
+    <section>
+      <h3>Listado de Cursos</h3>
+      <ul id="courses"></ul>
+    </section>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -3,46 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <title>Plataforma Educativa</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Plataforma de Cursos</h1>
-
-  <section id="register">
-    <h2>Registro</h2>
-    <input id="reg-name" placeholder="Nombre" />
-    <input id="reg-email" placeholder="Email" />
-    <input id="reg-pass" placeholder="Contraseña" type="password" />
-    <select id="reg-role">
-      <option value="student">Estudiante</option>
-      <option value="teacher">Maestro</option>
-    </select>
-    <button onclick="register()">Registrarse</button>
-    <div id="reg-result"></div>
-  </section>
-
-  <section id="login">
-    <h2>Ingreso</h2>
-    <input id="log-email" placeholder="Email" />
-    <input id="log-pass" placeholder="Contraseña" type="password" />
-    <button onclick="login()">Ingresar</button>
-    <div id="log-result"></div>
-  </section>
-
-  <section id="course-create">
-    <h2>Crear Curso (Maestros)</h2>
-    <input id="course-title" placeholder="Título" />
-    <input id="course-description" placeholder="Descripción" />
-    <textarea id="course-content" placeholder="Contenido"></textarea>
-    <button onclick="createCourse()">Crear</button>
-    <div id="course-result"></div>
-  </section>
-
-  <section>
-    <h2>Listado de Cursos</h2>
-    <button onclick="loadCourses()">Cargar Cursos</button>
-    <ul id="courses"></ul>
-  </section>
-
-  <script src="script.js"></script>
+  <nav>
+    <a href="login.html">Ingresar</a>
+    <a href="register.html">Registrarse</a>
+    <a href="courses.html">Cursos</a>
+  </nav>
+  <div class="container">
+    <h1>Bienvenido a la Plataforma de Cursos</h1>
+    <p>Explora contenido creado por la comunidad y comparte tus conocimientos.</p>
+  </div>
 </body>
 </html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Ingreso</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Inicio</a>
+    <a href="register.html">Registrarse</a>
+  </nav>
+  <div class="container">
+    <h2>Ingreso</h2>
+    <input id="log-email" placeholder="Email" />
+    <input id="log-pass" placeholder="Contraseña" type="password" />
+    <button onclick="login()">Ingresar</button>
+    <div id="log-result"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/profile.html
+++ b/public/profile.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Perfil</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body onload="loadProfile()">
+  <nav>
+    <a href="home.html">Home</a>
+    <a href="courses.html">Cursos</a>
+    <a href="#" onclick="logout()">Salir</a>
+  </nav>
+  <div class="container">
+    <h2>Perfil de Usuario</h2>
+    <p><strong>Nombre:</strong> <span id="prof-name"></span></p>
+    <p><strong>Email:</strong> <span id="prof-email"></span></p>
+    <p><strong>Rol:</strong> <span id="prof-role"></span></p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Registro</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Inicio</a>
+    <a href="login.html">Ingresar</a>
+  </nav>
+  <div class="container">
+    <h2>Registro</h2>
+    <input id="reg-name" placeholder="Nombre" />
+    <input id="reg-email" placeholder="Email" />
+    <input id="reg-pass" placeholder="Contraseña" type="password" />
+    <select id="reg-role">
+      <option value="student">Estudiante</option>
+      <option value="teacher">Maestro</option>
+    </select>
+    <button onclick="register()">Registrarse</button>
+    <div id="reg-result"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f2f5;
+  margin: 0;
+  padding: 0;
+}
+
+nav {
+  background: #343a40;
+  padding: 10px;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 15px;
+  text-decoration: none;
+}
+
+.container {
+  max-width: 600px;
+  margin: 40px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+input, select, textarea {
+  width: 100%;
+  padding: 8px;
+  margin: 8px 0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 10px 20px;
+  background: #007bff;
+  border: none;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #0056b3;
+}

--- a/src/routes.auth.js
+++ b/src/routes.auth.js
@@ -34,7 +34,7 @@ router.post('/login', (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
     const token = jwt.sign({ id: user.id, role: user.role }, SECRET, { expiresIn: '1h' });
-    return res.json({ token });
+    return res.json({ token, name: user.name, email: user.email, role: user.role });
   });
 });
 


### PR DESCRIPTION
## Summary
- Return user name, email and role on login for client use
- Split single-page UI into login, registration, home, profile and courses views
- Add shared script utilities and CSS to improve layout and navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689de7f892a08325b1a1736a383327f7