### PR TITLE
feat: onboarding preferences and course search

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -23,6 +23,7 @@
     </section>
     <section>
       <h3>Listado de Cursos</h3>
+      <input id="course-search" placeholder="Buscar cursos" oninput="searchCourses()" />
       <ul id="courses"></ul>
     </section>
   </div>

--- a/public/profile.html
+++ b/public/profile.html
@@ -16,6 +16,7 @@
     <p><strong>Nombre:</strong> <span id="prof-name"></span></p>
     <p><strong>Email:</strong> <span id="prof-email"></span></p>
     <p><strong>Rol:</strong> <span id="prof-role"></span></p>
+    <p><strong>Intereses:</strong> <span id="prof-pref"></span></p>
   </div>
   <script src="script.js"></script>
 </body>

--- a/public/setup.html
+++ b/public/setup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Configuración Inicial</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body onload="requireAuth()">
+  <nav>
+    <a href="#" onclick="logout()">Salir</a>
+  </nav>
+  <div class="container">
+    <h2>Cuéntanos tus intereses</h2>
+    <input id="pref-input" placeholder="Ej: matemáticas, historia" />
+    <button onclick="savePreferences()">Guardar</button>
+    <div id="pref-result"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/src/db.js
+++ b/src/db.js
@@ -7,8 +7,12 @@ db.serialize(() => {
     name TEXT NOT NULL,
     email TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
-    role TEXT NOT NULL CHECK(role IN ('teacher','student'))
+    role TEXT NOT NULL CHECK(role IN ('teacher','student')),
+    preferences TEXT
   )`);
+
+  // Ensure preferences column exists for older databases
+  db.run('ALTER TABLE users ADD COLUMN preferences TEXT', () => {});
 
   db.run(`CREATE TABLE IF NOT EXISTS courses (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/routes.course.js
+++ b/src/routes.course.js
@@ -5,7 +5,15 @@ const { authenticate } = require('./middleware.auth');
 const router = express.Router();
 
 router.get('/', (req, res) => {
-  db.all('SELECT courses.*, users.name as teacher_name FROM courses JOIN users ON courses.teacher_id = users.id', [], (err, rows) => {
+  const { search } = req.query;
+  let sql = 'SELECT courses.*, users.name as teacher_name FROM courses JOIN users ON courses.teacher_id = users.id';
+  const params = [];
+  if (search) {
+    sql += ' WHERE courses.title LIKE ? OR courses.description LIKE ?';
+    const like = `%${search}%`;
+    params.push(like, like);
+  }
+  db.all(sql, params, (err, rows) => {
     if (err) return res.status(500).json({ error: 'Database error' });
     return res.json(rows);
   });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -31,6 +31,7 @@ describe('API', () => {
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
     token = res.body.token;
+    expect(res.body.preferences).toBeNull();
   });
 
   test('create course', async () => {
@@ -46,5 +47,29 @@ describe('API', () => {
     const res = await request(app).get('/api/courses');
     expect(res.status).toBe(200);
     expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('search courses', async () => {
+    const res = await request(app).get('/api/courses?search=Mate');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].title).toBe('Matemáticas');
+  });
+
+  test('set preferences', async () => {
+    const res = await request(app)
+      .put('/api/preferences')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ preferences: 'math' });
+    expect(res.status).toBe(200);
+  });
+
+  test('login returns preferences', async () => {
+    const res = await request(app).post('/api/login').send({
+      email: 'prof@example.com',
+      password: 'pass'
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.preferences).toBe('math');
   });
 });


### PR DESCRIPTION
## Summary
- add user preferences column and API to update them
- redirect new users to an onboarding page to save their interests
- support course filtering by search term

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df288b60483258e88387aa5100018